### PR TITLE
fix: align release automation with GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,12 @@ Versioning is managed by `release-plz` and driven by conventional commits.
 The release workflow runs on pushes to `main`:
 
 1. `release-plz` opens or updates a release PR with the next version and changelog.
-2. Merging that PR creates the git tag and GitHub release.
+2. Merging that release PR creates the git tag and GitHub release.
 3. The release asset workflow builds macOS binaries and uploads tarballs plus SHA-256 checksum files to that release.
+
+GitHub repository setup required:
+
+- In `Settings > Actions > General`, enable `Allow GitHub Actions to create and approve pull requests` so the `release-plz` PR job can open the release PR.
 
 Local preview commands:
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,8 +2,10 @@
 features_always_increment_minor = true
 git_release_enable = true
 pr_labels = ["release"]
+release_always = false
 repo_url = "https://github.com/harshsandhu44/termeme-cli"
 
 [[package]]
 name = "termeme-cli"
 changelog_path = "CHANGELOG.md"
+publish = false

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -131,6 +131,7 @@ fn bundled_asset_bytes(filename: &str) -> Option<&'static [u8]> {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn command_in_path(command: &str) -> bool {
     let Some(paths) = env::var_os("PATH") else {
         return false;


### PR DESCRIPTION
## Summary
- stop release-plz from attempting crates.io publishing
- only release after merging a release PR
- document the required GitHub Actions permission for release PR creation
- suppress the dead-code warning that appeared during package verification

## Testing
- cargo check --locked
- cargo test --locked
- cargo clippy --all-targets --all-features -- -D warnings